### PR TITLE
check build status for all branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -2,15 +2,13 @@
 
 const got = require('got')
 const assert = require('assert')
+const ghauth = require('ghauth')
+const GitHub = require('github')
+const query = process.argv.slice(2)[0]
 require('colors')
 
-const commit = process.argv[2]
-
-assert(commit, `specify a commit SHA as the first argument`)
-assert(commit.length === 40, `full 40-character SHA is required`)
-
+const authOptions = {configName: 'libcc-check', note: 'electron/libcc-check'}
 const url = 'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
-
 const platforms = [
   'osx/x64',
   'mas/x64',
@@ -19,28 +17,56 @@ const platforms = [
   'linux/ia32',
   'linux/x64',
   'linux/arm'
-].sort()
+]
+const branches = []
 
-async function fetch (platform, commit) {
-  const fullURL = `${url}/${platform}/${commit}/libchromiumcontent.zip`
-  try {
-    await got.head(fullURL)
-    return {platform, available: true}
-  } catch (error) {
-    return {platform, available: false}
-  }
-}
+ghauth(authOptions, function (err, authData) {
+  const github = new GitHub()
+  github.authenticate({type: 'token', token: authData.token})
 
-function logResult ({platform, available}) {
-  if (available) {
-    console.log(`${'\u2713'.green} ${platform}`)
-  } else {
-    console.log(`${'\u2717'.red} ${platform}`)
-  }
-}
+  github.repos.getBranches({owner: 'electron', repo: 'libchromiumcontent'})
+    .then(res => {
+      const assets = []
+      res.data.forEach(branch => {
+        platforms.forEach(platform => {
+          assets.push({
+            branch: branch.name,
+            commit: branch.commit.sha,
+            platform: platform,
+            url: `${url}/${platform}/${branch.commit.sha}/libchromiumcontent.zip`
+          })
+        })
+      })
 
-Promise.all(platforms.map((platform) => {
-  return fetch(platform, commit)
-})).then((platforms) => {
-  platforms.forEach(logResult)
+      return Promise.all(assets.map(asset => fetch(asset)))
+    })
+    .then((assets) => {
+      const matches = assets
+        .filter(asset => !query || JSON.stringify(asset).includes(query))
+
+      if (!matches.length) {
+        console.log(`No matches found for ${query}. Try again without a query.`)
+      }
+
+      matches.forEach((asset, i) => {
+          const status = asset.available ? '\u2713'.green : '\u2717'.red
+          
+          // add space between branches
+          if (!query && i > 0 && asset.branch != assets[i-1].branch) console.log('')
+
+          console.log(`${status} ${asset.branch} - ${asset.commit} - ${asset.platform}`)
+        })
+    })
+    .catch(err => {
+      throw err
+    })
 })
+
+async function fetch (asset) {
+  try {
+    await got.head(asset.url)
+    return Object.assign(asset, {available: true})
+  } catch (error) {
+    return Object.assign(asset, {available: false})
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "license": "MIT",
   "dependencies": {
     "colors": "^1.1.2",
+    "ghauth": "^3.2.1",
+    "github": "^9.2.0",
     "got": "^7.1.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 A little tool for checking up on [libchromiumcontent](https://github.com/electron/libchromiumcontent) builds.
 
+It checks all open branches and displays the status of compiled assets for each.
+
 ## Installation
 
 ```sh
@@ -10,19 +12,44 @@ npm i -g electron/libcc-check
 
 ## Usage
 
-Pass the SHA you're interested in to find out if it's been successfully 
-compiled for all targets:
+To see status for all remote branches, run the command with no arguments.
 
 ```
-libcc-check 7a9d4a1c9c265468dd54005f6c1920b2cc2c8ec3
-✓ linux/arm
-✓ linux/ia32
-✓ linux/x64
-✓ mas/x64
-✓ osx/x64
-✓ win/ia32
-✓ win/x64
+libcc-check
 ```
+
+The first time you run the CLI, you'll be asked to authenticate with your GitHub
+account. The token is stored in your home directory so this will only happen 
+once.
+
+You can also filter by a specific commit SHA:
+
+```
+libcc-check ebaf0cac1543c32b6a7a567aad95ca051d3a0607
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - osx/x64
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - mas/x64
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - win/ia32
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - win/x64
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - linux/ia32
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - linux/x64
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - linux/arm
+```
+
+Or by branch name:
+
+```
+libcc-check upgrade-to-chromium-59
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - osx/x64
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - mas/x64
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - win/ia32
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - win/x64
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - linux/ia32
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - linux/x64
+✓ upgrade-to-chromium-59 - ebaf0cac1543c32b6a7a567aad95ca051d3a0607 - linux/arm
+```
+
+You could also just `libcc-check | grep foo`, but  then you'd lose the colored 
+output.
 
 ## License
 


### PR DESCRIPTION
There's currently a lot of back-and-forth to check the status of libcc's build artifacts. This PR is an attempt to show the whole picture with one command. The CLI hits the GitHub API, gathers a list of libcc's open branches, then checks for the existence of all assets on S3. On first run, it uses [ghauth](http:ghub.io/ghauth) to dynamically generate a token.

![screen shot 2017-08-01 at 3 15 16 pm](https://user-images.githubusercontent.com/2289/28849535-4461e69c-76cc-11e7-8b99-8b81f56f9291.png)

cc @vanessayuenn @kevinsawicki @zcbenz 