### PR TITLE
Explicitly state minumum required Node.js version to be 7.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "repository": "https://github.com/electron/libcc-check",
   "author": "Zeke Sikelianos <zeke@sikelianos.com>",
   "license": "MIT",
+  "engines" : {
+    "node" : ">=7.6.0"
+  },
   "dependencies": {
     "colors": "^1.1.2",
     "ghauth": "^3.2.1",

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,10 @@ A little tool for checking up on [libchromiumcontent](https://github.com/electro
 
 It checks all open branches and displays the status of compiled assets for each.
 
+## Requirements
+
+Node.js version 7.6.0 or above.
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
Async/await are not available in V8 prior version 5.5 [1],
and Node.js switched to V8 5.5 only in version 7.6.0 [2].

Entry in the package.json is not enough because it isn't used
unless user has set npm config's `engine-strict` to `true`,
while its default value is `false` [3].

[1] https://v8project.blogspot.ru/2016/10/v8-release-55.html
[2] https://nodejs.org/en/blog/release/v7.6.0/
[3] https://docs.npmjs.com/misc/config#engine-strict

/cc @zeke 